### PR TITLE
conditionally add MiniCssExtractPlugin, supress missing TS export warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@sewing-kit/cli": "^0.1.6",
     "@shopify/eslint-plugin": "^37.0.1",
     "@shopify/jest-dom-mocks": "^2.9.1",
+    "@shopify/webpack-ignore-typescript-export-warnings-plugin": "^1.0.4",
     "@storybook/addon-knobs": "5.3.18",
     "@storybook/preact": "5.3.8",
     "@types/faker": "^4.1.12",

--- a/src/webpack-config.ts
+++ b/src/webpack-config.ts
@@ -8,16 +8,19 @@ const SVG_ICONS_PATH_REGEX = /icons\/.*\.svg$/;
 const IMAGE_PATH_REGEX = /\.(jpe?g|png|gif|svg)$/;
 const LIBRARY_REGEX = /node_modules\/@shopify\/checkout-ui-react/;
 
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const {
+  IgnoreTypeScriptExportWarnings,
+} = require('@shopify/webpack-ignore-typescript-export-warnings-plugin');
+const postcssPresetEnv = require('postcss-preset-env');
+const postcssFunctions = require('postcss-functions');
+const postcssLogical = require('postcss-logical');
+const postcssDirPseudoClass = require('postcss-dir-pseudo-class');
+
 export function addWebpackConfig(
   config: Configuration,
   {preact = true, development = process.env.NODE_ENV === 'development'} = {},
 ): Configuration {
-  const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-  const postcssPresetEnv = require('postcss-preset-env');
-  const postcssFunctions = require('postcss-functions');
-  const postcssLogical = require('postcss-logical');
-  const postcssDirPseudoClass = require('postcss-dir-pseudo-class');
-
   return {
     ...config,
     resolve: {
@@ -173,5 +176,19 @@ export function addWebpackConfig(
         },
       ],
     },
+    plugins: [
+      ...(config.plugins ?? []),
+      new IgnoreTypeScriptExportWarnings(),
+      !hasMiniCssExtractPlugin(config) && new MiniCssExtractPlugin(),
+    ].filter(Boolean),
   };
+}
+
+function hasMiniCssExtractPlugin(config: Configuration) {
+  if (!config.plugins) {
+    return false;
+  }
+  return config.plugins.some((plugin) => {
+    return plugin instanceof MiniCssExtractPlugin;
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,6 +1876,11 @@
     promise "^8.0.3"
     tslib "^1.9.3"
 
+"@shopify/webpack-ignore-typescript-export-warnings-plugin@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@shopify/webpack-ignore-typescript-export-warnings-plugin/-/webpack-ignore-typescript-export-warnings-plugin-1.0.4.tgz#372aa8ed900533df84bb1013b7a243855113bfad"
+  integrity sha512-72vM0Ak3SzoralzoWD5opzzJd8zS767K7ihgymnYW/b9jUELXjPdixJgvcL3OrKwDWnuhpMtuIp3wvSxx52Ltg==
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"


### PR DESCRIPTION
- Removes warnings for missing TS exports
- adds MiniCssExtractPlugin if it doesn't exist to allow consumers to create a production bundle without having to do that themselves. Otherwise the build fails with an error. Caveat: the check will fail when the consumer uses a different version of MiniCssExtractPlugin, but I guess in that case we'll have other issues anyways. 